### PR TITLE
Skip email verification in development

### DIFF
--- a/template/app/main.wasp
+++ b/template/app/main.wasp
@@ -43,6 +43,7 @@ app OpenSaaS {
         emailVerification: {
           clientRoute: EmailVerificationRoute,
           getEmailContentFn: import { getVerificationEmailContent } from "@src/auth/email-and-pass/emails",
+          skipInDev: true
         },
         passwordReset: {
           clientRoute: PasswordResetRoute,

--- a/template/app/src/auth/email-and-pass/EmailVerificationPage.tsx
+++ b/template/app/src/auth/email-and-pass/EmailVerificationPage.tsx
@@ -3,6 +3,16 @@ import { VerifyEmailForm } from 'wasp/client/auth';
 import { AuthPageLayout } from '../AuthPageLayout';
 
 export function EmailVerificationPage() {
+  if (process.env.SKIP_EMAIL_VERIFICATION_IN_DEV === 'true') {
+    return (
+      <AuthPageLayout>
+        <span className='text-sm font-medium text-gray-900'>
+          Email verification is skipped in development mode.
+        </span>
+      </AuthPageLayout>
+    );
+  }
+
   return (
     <AuthPageLayout>
       <VerifyEmailForm />

--- a/template/app/src/auth/email-and-pass/emails.ts
+++ b/template/app/src/auth/email-and-pass/emails.ts
@@ -1,13 +1,23 @@
 import { type GetVerificationEmailContentFn, type GetPasswordResetEmailContentFn } from 'wasp/server/auth';
 
-export const getVerificationEmailContent: GetVerificationEmailContentFn = ({ verificationLink }) => ({
-  subject: 'Verify your email',
-  text: `Click the link below to verify your email: ${verificationLink}`,
-  html: `
+export const getVerificationEmailContent: GetVerificationEmailContentFn = ({ verificationLink }) => {
+  if (process.env.SKIP_EMAIL_VERIFICATION_IN_DEV === 'true') {
+    return {
+      subject: 'Email verification skipped',
+      text: 'Email verification is skipped in development mode.',
+      html: '<p>Email verification is skipped in development mode.</p>',
+    };
+  }
+
+  return {
+    subject: 'Verify your email',
+    text: `Click the link below to verify your email: ${verificationLink}`,
+    html: `
         <p>Click the link below to verify your email</p>
         <a href="${verificationLink}">Verify email</a>
     `,
-});
+  };
+};
 
 export const getPasswordResetEmailContent: GetPasswordResetEmailContentFn = ({ passwordResetLink }) => ({
   subject: 'Password reset',


### PR DESCRIPTION
Add functionality to skip email verification in development environment.

* **main.wasp**: Add `skipInDev: true` to the email verification configuration.
* **emails.ts**: Add a check for `SKIP_EMAIL_VERIFICATION_IN_DEV` to skip email verification in development mode and return a different email content.
* **EmailVerificationPage.tsx**: Add a check for `SKIP_EMAIL_VERIFICATION_IN_DEV` to skip rendering the email verification form in development mode and display a message instead.

